### PR TITLE
Fix contact_update tool birthdate handling

### DIFF
--- a/src/main/java/com/monicahq/mcp/controller/McpToolRegistry.java
+++ b/src/main/java/com/monicahq/mcp/controller/McpToolRegistry.java
@@ -683,11 +683,11 @@ public class McpToolRegistry {
         properties.put("birthdate", Map.of(
             "type", "string",
             "format", "date",
-            "description", "Birthdate in YYYY-MM-DD format (optional)"
+            "description", "Birthdate in YYYY-MM-DD format (optional). When provided, isBirthdateKnown will automatically be set to true."
         ));
         properties.put("isBirthdateKnown", Map.of(
             "type", "boolean",
-            "description", "Whether the birthdate is known (optional - defaults to existing value)"
+            "description", "Whether the birthdate is known (optional - defaults to existing value, automatically set to true when birthdate is provided)"
         ));
         properties.put("isDeceased", Map.of(
             "type", "boolean",

--- a/src/main/java/com/monicahq/mcp/service/ContactService.java
+++ b/src/main/java/com/monicahq/mcp/service/ContactService.java
@@ -90,6 +90,14 @@ public class ContactService {
                         updateData.put("genderId", existingData.get("gender_id"));
                     }
                     
+                    // Handle birthdate logic - if birthdate is provided, automatically set isBirthdateKnown to true
+                    if (updateData.containsKey("birthdate") && updateData.get("birthdate") != null 
+                        && !updateData.get("birthdate").toString().trim().isEmpty()) {
+                        // If birthdate is provided, ensure isBirthdateKnown is true
+                        updateData.put("isBirthdateKnown", true);
+                        log.info("Setting isBirthdateKnown=true because birthdate was provided");
+                    }
+                    
                     // Always include required boolean fields
                     if (!updateData.containsKey("isBirthdateKnown")) {
                         Object value = existingData.get("is_birthdate_known");
@@ -382,6 +390,26 @@ public class ContactService {
                 case "isDeceased" -> apiRequest.put("is_deceased", value);
                 case "isDeceasedDateKnown" -> apiRequest.put("is_deceased_date_known", value);
                 case "jobTitle" -> apiRequest.put("job_title", value);
+                case "birthdate" -> {
+                    // MonicaHQ API expects day, month, year instead of YYYY-MM-DD
+                    if (value != null && !value.toString().trim().isEmpty()) {
+                        try {
+                            String birthdateStr = value.toString();
+                            String[] parts = birthdateStr.split("-");
+                            if (parts.length == 3) {
+                                apiRequest.put("year", parts[0]);
+                                apiRequest.put("month", parts[1]);
+                                apiRequest.put("day", parts[2]);
+                                log.info("Converted birthdate {} to year={}, month={}, day={}", 
+                                    birthdateStr, parts[0], parts[1], parts[2]);
+                            } else {
+                                log.warn("Invalid birthdate format: {}, expected YYYY-MM-DD", birthdateStr);
+                            }
+                        } catch (Exception e) {
+                            log.error("Error parsing birthdate {}: {}", value, e.getMessage());
+                        }
+                    }
+                }
                 default -> apiRequest.put(key, value);
             }
         });


### PR DESCRIPTION
## Summary
- Fixes birthdate update issues in the contact_update MCP tool
- Automatically sets `isBirthdateKnown=true` when birthdate is provided
- Converts date format to Monica API's required structure

## Problem
The `contact_update` tool had two critical issues reported by Claude Desktop users:
1. When passing just `birthdate`: Updates returned success but didn't actually update the birthdate
2. When adding `isBirthdateKnown: true`: Tool execution failed completely

## Root Cause
1. Monica API requires `isBirthdateKnown=true` when updating birthdate, but the tool didn't set this automatically
2. Monica API expects birthdate as separate `day`, `month`, `year` fields, not `birthdate: "YYYY-MM-DD"`

## Solution
### 1. Automatic Flag Setting
- When `birthdate` is provided, automatically set `isBirthdateKnown=true`
- Added logging to track this behavior

### 2. Date Format Conversion
- Convert `birthdate: "1990-05-15"` to:
  - `year: "1990"`
  - `month: "05"`  
  - `day: "15"`
- Added robust error handling for invalid date formats

### 3. Documentation Updates
- Updated tool schema descriptions to clarify automatic behavior
- Made the relationship between birthdate and isBirthdateKnown explicit

## Test Plan
- [x] Test updating birthdate with just `birthdate` field
- [x] Test updating birthdate with both `birthdate` and `isBirthdateKnown: true`
- [x] Test invalid date format handling
- [x] Verify Monica API receives correct field format
- [ ] Test via Claude Desktop integration

## Breaking Changes
None - this is a backward-compatible fix that makes the tool more intuitive.

🤖 Generated with [Claude Code](https://claude.ai/code)