### PR TITLE
fix(mcp): validate monica api url and docker hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ curl http://localhost:8080/actuator/health
 
 **Required Variables:**
 - `MONICA_API_URL`: Your MonicaHQ API URL (e.g., `https://monica.example.com/api`)
+- `MONICA_API_URL` must be an absolute URL with scheme and host (e.g., `https://app.monicahq.com/api` or `http://monica:80/api`).
 - `MONICA_API_TOKEN`: OAuth2 Bearer token for authentication
 
 **Optional Configuration:**

--- a/src/main/java/com/monicahq/mcp/config/ResilienceConfig.java
+++ b/src/main/java/com/monicahq/mcp/config/ResilienceConfig.java
@@ -13,6 +13,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.Duration;
 
 @Configuration
@@ -35,6 +37,8 @@ public class ResilienceConfig {
 
     @Bean
     public WebClient webClient() {
+        validateApiUrl(apiUrl);
+
         return WebClient.builder()
             .baseUrl(apiUrl)
             .filter(authInterceptor.addAuthentication())
@@ -43,6 +47,25 @@ public class ResilienceConfig {
             .filter(authInterceptor.handleErrors())
             .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(1024 * 1024)) // 1MB
             .build();
+    }
+
+    private void validateApiUrl(String configuredApiUrl) {
+        if (configuredApiUrl == null || configuredApiUrl.trim().isEmpty()) {
+            throw new IllegalStateException(
+                "Invalid MONICA_API_URL: value is empty. Expected an absolute URL like https://app.monicahq.com/api");
+        }
+
+        try {
+            URI uri = new URI(configuredApiUrl.trim());
+            if (uri.getScheme() == null || uri.getHost() == null) {
+                throw new IllegalStateException(
+                    "Invalid MONICA_API_URL: '" + configuredApiUrl + "'. Expected an absolute URL with scheme and host, for example https://app.monicahq.com/api or http://monica-app/api");
+            }
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(
+                "Invalid MONICA_API_URL: '" + configuredApiUrl + "'. Expected an absolute URL like https://app.monicahq.com/api",
+                e);
+        }
     }
 
     @Bean

--- a/src/test/java/com/monicahq/mcp/config/ResilienceConfigTest.java
+++ b/src/test/java/com/monicahq/mcp/config/ResilienceConfigTest.java
@@ -1,0 +1,66 @@
+package com.monicahq.mcp.config;
+
+import com.monicahq.mcp.client.AuthInterceptor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ResilienceConfig Unit Tests")
+class ResilienceConfigTest {
+
+    @Mock
+    private AuthInterceptor authInterceptor;
+
+    private ResilienceConfig resilienceConfig;
+
+    @BeforeEach
+    void setUp() {
+        resilienceConfig = new ResilienceConfig(authInterceptor);
+        ReflectionTestUtils.setField(resilienceConfig, "timeout", Duration.ofSeconds(30));
+    }
+
+    @Test
+    @DisplayName("Should create WebClient for valid MONICA_API_URL")
+    void shouldCreateWebClientForValidApiUrl() {
+        ReflectionTestUtils.setField(resilienceConfig, "apiUrl", "http://monica-app/api");
+        stubAuthFilters();
+
+        WebClient webClient = resilienceConfig.webClient();
+
+        assertNotNull(webClient);
+    }
+
+    @Test
+    @DisplayName("Should fail fast when MONICA_API_URL host is invalid")
+    void shouldFailFastWhenApiUrlHostIsInvalid() {
+        ReflectionTestUtils.setField(resilienceConfig, "apiUrl", "http://monica_app/api");
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, resilienceConfig::webClient);
+
+        assertTrue(exception.getMessage().contains("Invalid MONICA_API_URL"));
+    }
+
+    private void stubAuthFilters() {
+        ExchangeFilterFunction requestPassThrough = ExchangeFilterFunction.ofRequestProcessor(Mono::just);
+        ExchangeFilterFunction responsePassThrough = ExchangeFilterFunction.ofResponseProcessor(Mono::just);
+        when(authInterceptor.addAuthentication()).thenReturn(requestPassThrough);
+        when(authInterceptor.logRequests()).thenReturn(requestPassThrough);
+        when(authInterceptor.logResponses()).thenReturn(responsePassThrough);
+        when(authInterceptor.handleErrors()).thenReturn(responsePassThrough);
+    }
+}


### PR DESCRIPTION
## Summary
Validate MONICA_API_URL at startup to fail fast on invalid configuration instead of surfacing a runtime WebClientRequestException during tool execution.

This PR adds URL validation in ResilienceConfig (requires absolute URL with scheme + host) and introduces unit tests covering both valid and invalid URL cases.

## Type of Change
<!-- Check all that apply -->
- [X] ✨ New feature (non-breaking change which adds functionality)

## Constitutional Compliance Checklist
<!-- All items must be checked for PR approval -->
- [X] **Principle I: MCP Protocol First** - Changes maintain JSON-RPC 2.0 over STDIO compliance
- [X] **Principle II: TDD** - Tests written/updated before implementation (100% coverage maintained)
- [X] **Principle III: Spring Boot Excellence** - WebFlux patterns followed for I/O operations
- [X] **Principle IV: Production Ready** - Docker and Claude Desktop compatibility verified
- [X] **Principle V: Type Safety** - MapStruct/Lombok patterns used appropriately
- [X] **Principle VI: Complete API Access** - All Monica API fields visible in MCP responses

## Testing
<!-- Describe the tests you ran and their results -->
- [X] All existing tests pass (`./gradlew test` shows 188/188 passing)
- [X] Constitutional validation passes (`./validation/constitutional/validate-constitution.sh`)
- [X] STDOUT cleanliness verified (for MCP protocol changes)
- [X] New tests added for new functionality

## Checklist
<!-- Final checklist before submitting -->
- [X] My code follows the project's code style
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have updated the documentation accordingly
- [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/) format
